### PR TITLE
Fix GitHub Actions badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🚀 Slack SDK for Go
 
-[![Go Build](https://github.com/PramithaMJ/slack-sdk-go/actions/workflows/go.yml/badge.svg)](https://github.com/PramithaMJ/slack-sdk-go/actions/workflows/go.yml)
-[![GitHub Workflow Status](https://github.com/PramithaMJ/slack-sdk-go/actions/workflows/main.yml/badge.svg)](https://github.com/PramithaMJ/slack-sdk-go/actions/workflows/main.yml)
+[![Go](https://github.com/PramithaMJ/slack-sdk-go/workflows/Go/badge.svg)](https://github.com/PramithaMJ/slack-sdk-go/actions/workflows/go.yml)
+[![CI](https://github.com/PramithaMJ/slack-sdk-go/workflows/CI/badge.svg)](https://github.com/PramithaMJ/slack-sdk-go/actions/workflows/main.yml)
 
 A **lightweight** and **modular** SDK for building Slack bots and apps in **Go**. With this SDK, you can easily send messages with Block Kit support, manage users, and extend functionality to integrate with the Slack API seamlessly.
 


### PR DESCRIPTION
## Changes

- Updated GitHub Actions badge URLs to use workflow names instead of file paths
- Changed 'Go Build' badge to use 'Go' (matching the name in go.yml workflow)
- Changed 'GitHub Workflow Status' badge to use 'CI' (matching the name in main.yml workflow)

This will fix the badge status display in the README.